### PR TITLE
Tweak App Engine setup and use service account impersonation

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -7,19 +7,7 @@
 #   $ gcloud topic gcloudignore
 #
 .gcloudignore
-# If you would like to upload your .git directory, .gitignore file or files
-# from your .gitignore file, remove the corresponding line
-# below:
 .git
 .gitignore
-
-# Python pycache:
-__pycache__/
-# Ignored by the build system
-/setup.cfg
-
-# Secrets for local development only
-monorail-key.json
-
-# Build dependencies (bower)
-webapp/node_modules
+# Include the *top-level* .gitignore.
+#!include:.gitignore

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -18,8 +18,8 @@ __pycache__/
 # Ignored by the build system
 /setup.cfg
 
-# Secrets needed to deploy:
-!monorail-key.json
+# Secrets for local development only
+monorail-key.json
 
 # Build dependencies (bower)
 webapp/node_modules

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -20,3 +20,6 @@ __pycache__/
 
 # Secrets needed to deploy:
 !monorail-key.json
+
+# Build dependencies (bower)
+webapp/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ env/
 monorail-key.json
 *.pyc
 __pycache__/
+webapp/node_modules/
+webapp/bower_components/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
+# Note that this file is also included by .gcloudignore, i.e. all files matched
+# here will NOT be deployed.
+
 env/
-monorail-key.json
 *.pyc
 __pycache__/
+
+monorail-key.json
 webapp/node_modules/
-webapp/bower_components/
+# webapp/bower_components/ is in webapp/.gitignore as it needs to be deployed.

--- a/README.md
+++ b/README.md
@@ -10,17 +10,21 @@ If you reload often you might hit the GitHub API limit for unauthenticated reque
 If this happens, [generate a new access token](https://github.com/settings/tokens/new)
 and pass it in the URL: https://ecosystem-infra-rotation.appspot.com/#GH_TOKEN=abcdef
 
-This is an AppEngine project, so we assume you already have Google Cloud SDK (including
-Python plugins) set up locally.
+### Dependencies
 
-## Running locally
+This is an AppEngine project, so we assume you already have Google Cloud SDK
+(including Python plugins) set up locally.
 
-You will need `npm` as well as `python3` and `virtualenv`:
+You will need to have npm on your machine. (Instructions are omitted as they
+vary across platforms.) In addition, install `python3` and `virtualenv`, e.g.
+on Debian/Ubuntu:
 ```bash
 sudo apt install python3 virtualenv python3-venv
 ```
 
-To run locally:
+## Running locally
+
+To build and run the tool locally:
 ```bash
 ./build.sh && dev_appserver.py .
 ```
@@ -42,7 +46,7 @@ for more details/clues about how this works.
 
 ## Deploying
 
-To deploy:
+To build and deploy to production (you will need to `gcloud auth login` first):
 ```bash
 ./build.sh && ./deploy.sh
 ```

--- a/README.md
+++ b/README.md
@@ -1,35 +1,44 @@
 # Ecosystem Infra Rotation
 
-This is a tool for the [ecosystem infra](https://bit.ly/ecosystem-infra) rotation.
+This is a tool for the [Ecosystem Infra](https://bit.ly/ecosystem-infra) rotation.
 
 ## Usage
 
 Visit https://ecosystem-infra-rotation.appspot.com/ and follow the instructions.
 
 If you reload often you might hit the GitHub API limit for unauthenticated requests.
-If this happens, [generate a new access token](https://github.com/settings/tokens/new) and pass it in the URL: https://ecosystem-infra-rotation.appspot.com/#GH_TOKEN=abcdef
+If this happens, [generate a new access token](https://github.com/settings/tokens/new)
+and pass it in the URL: https://ecosystem-infra-rotation.appspot.com/#GH_TOKEN=abcdef
+
+This is an AppEngine project, so we assume you already have Google Cloud SDK (including
+Python plugins) set up locally.
 
 ## Running locally
 
-The build script needs Bower, Python 3 and Virtualenv:
+You will need `npm` as well as `python3` and `virtualenv`:
 ```bash
-sudo npm install -g bower
-sudo apt install python3 virtualenv
+sudo apt install python3 virtualenv python3-venv
 ```
 
 To run locally:
 ```bash
-./build.sh && ./serve.sh
+./build.sh && dev_appserver.py .
 ```
 
 This will serve the tool at http://localhost:8080/
 
-## API key
+When running locally, you also need a private key of a service account to access Monorail:
 
-The monorail queries require a `monorail-key.json` to be placed in a checkout of this repo.
-You can create a new API key and download a JSON file from the [ecosystem-infra GCP project](https://console.cloud.google.com/iam-admin/serviceaccounts/project?project=ecosystem-infra).
-If you don't have access and think you should, ask foolip or robertma.
-See the [Monorail API access](https://bugs.chromium.org/p/monorail/issues/detail?id=3234) request for more details/clues about how this works.
+### API key
+
+The Monorail queries require a `monorail-key.json` to be placed in a checkout of this repo.
+You can create a new JSON private key from the
+[ecosystem-infra GCP project](https://console.cloud.google.com/iam-admin/serviceaccounts/project?project=ecosystem-infra).
+If you don't have access and think you should, ask foolip or robertma. (Note
+that this is a different GCP project from the one we deploy to.)
+
+See [Monorail API access](https://bugs.chromium.org/p/monorail/issues/detail?id=3234)
+for more details/clues about how this works.
 
 ## Deploying
 
@@ -37,3 +46,13 @@ To deploy:
 ```bash
 ./build.sh && ./deploy.sh
 ```
+
+*You do NOT need `monorail-key.json` for deployment.*
+
+### Details about authentication
+
+The production deployment does not a private key because we use IAM Service
+Account Credentials API (`iamcredentials.googleapis.com`) to
+[create credentials](https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials)
+to impersonate the service account with access to Monorail from the default
+AppEngine service account.

--- a/app.yaml
+++ b/app.yaml
@@ -2,14 +2,22 @@ runtime: python37
 
 handlers:
   - url: /
+    secure: always
     static_files: webapp/index.html
     upload: webapp/index.html
 
   - url: /bower_components
+    secure: always
     static_dir: webapp/bower_components
 
   - url: /components
+    secure: always
     static_dir: webapp/components
 
   - url: /docs
+    secure: always
     static_dir: docs
+
+  - url: /api/.*
+    secure: always
+    script: auto

--- a/build.sh
+++ b/build.sh
@@ -6,4 +6,5 @@ set -o pipefail
 # Install webapp dependencies.
 cd webapp
 rm -rf bower_components
-bower install
+# This will call `bower install`.
+npm install

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,4 +4,4 @@ set -o nounset
 set -o pipefail
 
 VERSION="$(git describe --always --dirty --long)"
-gcloud app deploy --no-promote --project=ecosystem-infra-rotation --version="$VERSION"
+gcloud app deploy --project=ecosystem-infra-rotation --version="$VERSION"

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,11 +3,5 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-MONORAIL_KEY="monorail-key.json"
-if [[ ! -f "$MONORAIL_KEY" ]]; then
-    echo "$MONORAIL_KEY needed to deploy"
-    exit 1
-fi
-
 VERSION="$(git describe --always --dirty --long)"
-gcloud app deploy --project=ecosystem-infra-rotation --version="$VERSION"
+gcloud app deploy --no-promote --project=ecosystem-infra-rotation --version="$VERSION"

--- a/monorail.py
+++ b/monorail.py
@@ -1,16 +1,40 @@
 from oauth2client.client import GoogleCredentials
 import googleapiclient.discovery
+import google.auth.compute_engine
+import google.auth.impersonated_credentials
 
 DISCOVERY_URL = (
     'https://monorail-prod.appspot.com/_ah/api/discovery/v1/apis/'
     '{api}/{apiVersion}/rest')
 
+# https://cs.chromium.org/chromium/infra/go/src/infra/monorail/monorail.go?l=10&rcl=201f157c7ebc2be34ebeaa03ea47de2d8f4a8233
+MONORAIL_AUTH_SCOPE = 'https://www.googleapis.com/auth/userinfo.email'
+MONORAIL_SERVICE_ACCOUNT = 'monorail-api@ecosystem-infra.iam.gserviceaccount.com'
+# Local fallback.
 MONORAIL_KEY = 'monorail-key.json'
+
+_credentials = None
+
+
+def _get_credentials():
+    global _credentials
+    if _credentials:
+        return _credentials
+    try:
+        default_creds = google.auth.compute_engine.Credentials()
+        _credentials = google.auth.impersonated_credentials.Credentials(
+            source_credentials=default_creds,
+            target_principal=MONORAIL_SERVICE_ACCOUNT,
+            target_scopes=[MONORAIL_AUTH_SCOPE],
+        )
+    except EnvironmentError:
+        _credentials = GoogleCredentials.from_stream(MONORAIL_KEY)
+
+    return _credentials
 
 
 def query(q):
-    credentials = GoogleCredentials.from_stream(MONORAIL_KEY)
-
+    credentials = _get_credentials()
     monorail = googleapiclient.discovery.build(
         'monorail', 'v1',
         discoveryServiceUrl=DISCOVERY_URL,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask==1.0.2
-google-api-python-client==1.7.8
 MechanicalSoup==0.11.0
+google-api-python-client==1.7.8
+google-auth==1.6.3
 oauth2client==4.1.3

--- a/serve.sh
+++ b/serve.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -o errexit
-set -o nounset
-set -o pipefail
-
-dev_appserver.py app.yaml

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -1,1 +1,0 @@
-bower_components/

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -1,0 +1,1 @@
+bower_components/

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "ecosystem-infra-rotation",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bower": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.8.tgz",
+      "integrity": "sha512-1SrJnXnkP9soITHptSO+ahx3QKp3cVzn8poI6ujqc5SeOkg5iqM1pK9H+DSc2OQ8SnO0jC/NG4Ur/UIwy7574A==",
+      "dev": true
+    }
+  }
+}

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "ecosystem-infra-rotation",
+  "version": "1.0.0",
+  "description": "Rotation tool for the Chrome Ecosystem Infra team",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/foolip/ecosystem-infra-rotation.git"
+  },
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/foolip/ecosystem-infra-rotation/issues"
+  },
+  "homepage": "https://github.com/foolip/ecosystem-infra-rotation#readme",
+  "scripts": {
+    "install": "bower install"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "bower": "^1.8.8"
+  }
+}

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "git+https://github.com/foolip/ecosystem-infra-rotation.git"
   },
-  "license": "BSD-3-Clause",
+  "license": "UNLICENSED",
   "bugs": {
     "url": "https://github.com/foolip/ecosystem-infra-rotation/issues"
   },
@@ -16,6 +16,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "bower": "^1.8.8"
+    "bower": "1.8.8"
   }
 }


### PR DESCRIPTION
This is a follow-up change of https://github.com/foolip/ecosystem-infra-rotation/pull/4.

First, some nits are addressed. And `npm` is used to manage build process (this will help people who don't install the deprecated `bower` toolchain globally, as well as facilitate future migration to Polymer 3).

More importantly, this PR also changes the credential management so that a private key no longer needs to be deployed to production. See [this commit](https://github.com/foolip/ecosystem-infra-rotation/pull/5/commits/5f6537c70fcfdfb74332e95f0ac04625811fefa2) for more details.

Please rebase-merge this PR.