### PR TITLE
Add a naive way to refresh the dashboard

### DIFF
--- a/webapp/components/ecosystem-infra-rotation.html
+++ b/webapp/components/ecosystem-infra-rotation.html
@@ -247,6 +247,14 @@
             tasks: blinkInfraTaskInfo.map(crbugTask),
           },
         ];
+
+        // Naive support for refreshing the dashboard. A better solution would
+        // change the way tasks are stored so that they can be re-called.
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.has('refresh')) {
+          const refreshDelay = parseInt(urlParams.get('refresh')) * 1000;
+          setTimeout(() => { window.location.reload(false); }, refreshDelay);
+        }
       }
     }
 

--- a/webapp/components/ecosystem-infra-rotation.html
+++ b/webapp/components/ecosystem-infra-rotation.html
@@ -252,7 +252,8 @@
         // change the way tasks are stored so that they can be re-called.
         const urlParams = new URLSearchParams(window.location.search);
         if (urlParams.has('refresh')) {
-          const refreshDelay = parseInt(urlParams.get('refresh')) * 1000;
+          // Set a minimum refresh rate of 30s to avoid being spammed.
+          const refreshDelay = Math.max(parseInt(urlParams.get('refresh')), 30s) * 1000;
           setTimeout(() => { window.location.reload(false); }, refreshDelay);
         }
       }

--- a/webapp/components/ecosystem-infra-rotation.html
+++ b/webapp/components/ecosystem-infra-rotation.html
@@ -253,7 +253,7 @@
         const urlParams = new URLSearchParams(window.location.search);
         if (urlParams.has('refresh')) {
           // Set a minimum refresh rate of 30s to avoid being spammed.
-          const refreshDelay = Math.max(parseInt(urlParams.get('refresh')), 30s) * 1000;
+          const refreshDelay = Math.max(parseInt(urlParams.get('refresh')), 30) * 1000;
           setTimeout(() => { window.location.reload(false); }, refreshDelay);
         }
       }


### PR DESCRIPTION
This adds support for a query parameter, refresh=X. When set, after X
seconds the page will reload.