### PR TITLE
Fix auto deployment on GitHub Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,17 +1,17 @@
+name: Deploy master
 on:
   push:
     branches:
     - master
-name: master
 jobs:
-  deploy:
-    runs-on: ubuntu-18.04
+  build-and-deploy:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - run: ./build.sh
-    - uses: actions/gcloud/auth@master
-      env:
-        GCLOUD_AUTH: ${{ secrets.GCLOUD_AUTH }}
-    - uses: actions/gcloud/cli@master
+    - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
       with:
-        entrypoint: ./deploy.sh
+        service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+        service_account_key: ${{ secrets.GCP_SA_KEY }}
+    - run: gcloud info
+    - run: ./deploy.sh


### PR DESCRIPTION
Tested on my local fork: https://github.com/Hexcles/ecosystem-infra-rotation/runs/475540857

We'd need to add new secrets to the project, but I can't access repo settings. Apparently only the owner can change the settings of a personal repo. @foolip could you follow the instructions in https://github.com/GoogleCloudPlatform/github-actions/tree/master/setup-gcloud#inputs and add the two secrets?